### PR TITLE
ENH: construct dataset using tensorflow graph

### DIFF
--- a/tensorflow_reader/tensorflow_reader.py
+++ b/tensorflow_reader/tensorflow_reader.py
@@ -11,174 +11,6 @@ import tensorflow as tf
 import time
 
 
-def _assign_field(element, field, value):
-  #Consistent with tensorflow graphs, this function does not modify
-  #any of its inputs
-
-  #Add a field to a struct. Use with tf.data.Dataset.map.
-  return {**element, field: value}
-
-
-def _add_fields(elem, fields, values):
-  #Consistent with tensorflow graphs, this function does not modify
-  #any of its inputs
-
-  #Add fields to struct. Use with tf.data.Dataset.map.
-  element = {**elem}
-  for field, value in zip(fields, values):
-    element[field] = value
-  return element
-
-
-def _expand_tensors(elem, fields, reference):
-  #Consistent with tensorflow graphs, this function does not modify
-  #any of its inputs
-
-  #Expands tensor fields in dataset element to match the length of a reference
-  #field. This allows application of tf.data.Dataset.flat_map to expand from
-  #a read-chunk element dataset to a tile dataset using from_tensor_slices.
-
-  element = {**elem}
-  #get reference field length
-  length = tf.size(element[reference])
-
-  #This may lead to trouble when `reference` is of size/length 0
-  #because every key in `elem`, whether or not in `fields`, will end
-  #up being a list of length 0.  Unlike lists with a longer length,
-  #all shape information of each value (in the key-value pair) is lost
-  #with a list of length 0.  Especially if it is the first batch, this
-  #may cause a later `flat_map` or `unbatch` command to fail.
-
-  #iterate over fields removing singleton dimensions and repeating
-  for field in fields:
-    if tf.is_tensor(element[field]):
-      element[field] = tf.repeat(tf.squeeze(element[field]), length)
-
-    else: #raise exception - assume all fields are tensor type
-      raise ValueError('Field is not tensor.')
-
-  return element
-
-
-def _tile_coords(width, height, tw, th, ow, oh, fractional):
-#generates tiling coordinates for reading (th, tw) tiles with (ox, oy) overlap
-#from a (height, width) image.
-#For example, if image with `width` fits exactly `N` tiles with width `tw` and overlap `ow` then
-#  width == N * (tw-ow) + ow,
-#otherwise the tiles farthest to the right will not be of full width `tw`.
-# We omit these narrower tiles unless `fractional` is set to true.
-#... and similarly for heights instead of widths.
-
-  '''
-  if (tf.math.greater_equal(ow, tw)):
-    print("bool = %s, ow = %s, tw = %s" % (tf.math.greater_equal(ow, tw), ow, tw))
-    raise ValueError('Tile width overlap must be less than tile width.')
-  if (tf.math.greater_equal(oh, th)):
-    print("oh = %s, th = %s" % (oh, th))
-    raise ValueError('Tile height overlap must be less than tile height.')
-  '''
-
-  zero = tf.constant(0, dtype=tf.int32)
-  one = tf.constant(1, dtype=tf.int32)
-  #Generate list of read coordinates
-  left_limit = tf.maximum(zero, width-ow if fractional else width-tw+one)
-  left = tf.range(zero, left_limit, tw-ow)
-  right = tf.clip_by_value(left+tw, zero, width)
-
-  top_limit = tf.maximum(zero, height-oh if fractional else height-th+one)
-  top = tf.range(zero, top_limit, th-oh)
-  bottom = tf.clip_by_value(top+th, zero, height)
-  l = tf.repeat(left, tf.size(top))
-  w = tf.repeat(right-left, tf.size(top))
-  t = tf.tile(top, tf.stack([tf.size(left)]))
-  h = tf.tile(bottom-top, tf.stack([tf.size(left)]))
-
-  return l, t, w, h
-
-
-def _add_tile_coords_fields(element, tile, overlap):
-    tx, ty, tw, th = _tile_coords(element['cw'], element['ch'], tile[0], tile[1], overlap[0], overlap[1], False)
-    return _add_fields(element, ['tx', 'ty', 'tw', 'th', 'ow', 'oh'], [tx, ty, tw, th, overlap[0], overlap[1]])
-
-
-def get_read_parameters(filename, magnification, tolerance = 1e-2):
-
-  #read whole-slide image file and create openslide object
-  os_obj = os.OpenSlide(filename)
-
-  #measure objective of level 0
-  objective = np.float32(os_obj.properties[os.PROPERTY_NAME_OBJECTIVE_POWER])
-
-  #calculate magnifications of levels
-  estimated = np.array(objective / os_obj.level_downsamples)
-
-  #calculate difference with magnification levels
-  delta = magnification - estimated
-
-  #match to existing levels
-  if np.min(np.abs(np.divide(delta, magnification))) < tolerance: #match
-    level = np.squeeze(np.argmin(np.abs(delta)))
-    factor = 1.0
-  elif np.any(delta < 0):
-    value = np.max(delta[delta < 0])
-    level = np.squeeze(np.argwhere(delta == value)[0])
-    factor = magnification / estimated[level]
-  else: #desired magnification above base level - throw error
-    raise ValueError('Cannot interpolate above scan magnification.')
-
-  #get slide width, height at desired magnification
-  width, height = os_obj.level_dimensions[level]
-
-  return level, factor, width, height
-
-
-def read_region(filename, level, x, y, w, h):
-
-  #open slide
-  os_obj = os.OpenSlide(filename.numpy())
-
-  #read chunk and convert to tensor
-  chunk = os_obj.read_region((x.numpy(), y.numpy()),
-                             level.numpy(),
-                             (w.numpy(), h.numpy()))
-
-  return tf.convert_to_tensor(np.array(chunk)[...,:3], dtype=tf.uint8)
-
-
-def tf_read_region(filename, level, x, y, w, h):
-  return tf.py_function(func=read_region,
-                        inp=[filename, level, x, y, w, h],
-                        Tout=tf.uint8)
-
-
-def _read_chunk(element):
-
-  #read chunk and convert to tensor
-  chunk = tf_read_region(element['filename'],
-                         tf.cast(element['level'], dtype=tf.int32),
-                         element['cx'], element['cy'],
-                         element['cw'], element['ch'])
-
-  #split read chunk into tiles using a loop.
-  #this avoids copying 'chunk' with 'map_fn' or 'tf.image.generate_glimpse'
-  tiles = tf.TensorArray(dtype=tf.uint8, size=tf.size(element['tx']))
-  condition = lambda i, _: tf.less(i, tf.size(element['tx']))
-  body = lambda i, tiles: (i+1,
-                           tiles.write(i, tf.image.crop_to_bounding_box(chunk,
-                                                        tf.gather(element['ty'], i),
-                                                        tf.gather(element['tx'], i),
-                                                        tf.gather(element['th'], i),
-                                                        tf.gather(element['tw'], i))))
-  _, tiles = tf.while_loop(condition, body, [0, tiles])
-  tiles = tiles.stack()
-
-  #add tile tensor to element
-  element['tiles'] = tiles
-
-  #return dataset element dict
-  return element
-
-
 def _merge_dist_tensor(strategy, distributed, axis=0):
     #check if input is type roduced by distributed.Strategy.run
     if isinstance(distributed, tf.python.distribute.values.PerReplica):
@@ -197,130 +29,6 @@ def _merge_dist_dict(strategy, distributed, axis=0):
         raise ValueError('Input to _merge_dist_tensor not a dict.')
 
 
-def tiled(filename, slide='', case='', magnification=20.0, tile=(256, 256),
-          overlap=(0, 0), chunkFactor=(4, 4), mask=None):
-  """Generates a tf.data.Dataset where each element contains RGB pixel data
-  generated by a regular-grid tiling of the slide. This function generates an
-  intermediate dataset of 'read chunks' that contain many tiles, and that
-  defines the actual reads made from the whole-slide image file. Functions are
-  applied to tile these reads and stack them into a new dataset containing the
-  tiles. This function is used to stream tiles to downstream preprocessing,
-  inference, or training steps to hide read times with these compute-intensive
-  operations.
-
-  Related functions enable these tiles to be filtered and grouped by read chunk,
-  slide, or case to enable complex logic for controlling downstream operations
-  and for aggregating and organizing their outputs.
-
-  Each element in the tile dataset is a dict where the tile is stored in
-  element['tiles']. Metadata stored in other fields includes:
-
-    slide - name of slide without file extension
-    filename - filename and path of whole-slide image file.
-    case - string describing case that slide is associated with.
-    magnification - float describing objective magnification of tiles.
-    cx, cy - location of upper-left corner of read chunk in pixels at native
-      scan magnification. Used for calculating global coordinates.
-    cw, ch - parameter width and height of read chunk in pixels.
-    level - read level used to access pixel data from file.
-    factor - resizing factor applied to read chunk images read from `level`. If
-      < 1 then `magnification` is not available in the file and must be computed
-      from a high magnification.
-    tw, th - parameter tile width and height in pixels.
-    tx, ty - local coordates of tile in read chunk.
-    ow, oh - parameter overlap width and height in pixels.
-    read_mode - string containing.
-
-  Parameters
-  ----------
-  filename: string
-    Path and filename of the slide readable by openslide.
-  slide: string
-    Slide name (used for operations that gather tiles by slide). Default ''.
-  case: string
-    Case identifier (used for gather operations on tiles). Default ''.
-  magnification: float
-    Desired objective magnification of pixel data tiles extracted from
-    `filename`. Default 20.0.
-  tile: (int, int)
-    Tuple containing width and height respectively of extracted tiles. Default
-    (256, 256).
-  overlap: (int, int)
-    Tuple containing horizontal and vertical overlap of tiles. Default (0, 0).
-  chunkFactor: (int, int)
-    Number of overlapping tiles that fit in a chunk in each direction. Critical for performance.
-    These chunks are tiled and the tiles stacked to generate the output dataset.
-    Default (4, 4).
-  mask: array_like
-    Boolean mask of slide indicating where tiles should be extracted. Acceptable
-    types include _____.
-
-  Returns
-  -------
-  tiled: tf.data.Dataset
-    A dataset where each element contains an tuple of (RGB tile, metadata). The
-    tile and metadata are separated in the tuple to satisfy unpacking rules.
-
-  See Also
-  --------
-  dense: A function for generating tiles at arbitrary locations from a single
-    read.
-  """
-
-  level, factor, width, height = get_read_parameters(filename, magnification)
-
-  #**** error if magnification > native ****
-
-  chunk = (overlap[0] + chunkFactor[0] * (tile[0] - overlap[0]), overlap[1] + chunkFactor[1] * (tile[1] - overlap[1]))
-  #generate list of read coordinates (global frame, upper-left corner)
-  cx, cy, cw, ch = _tile_coords(width, height,
-                        chunk[0], chunk[1],
-                        overlap[0], overlap[1], True)
-
-  #generate read chunk dataset
-  read = tf.data.Dataset.from_tensor_slices({'cx': cx, 'cy': cy, 'cw': cw, 'ch': ch})
-
-  #add general parameters
-  read = read.map(lambda elem: _add_fields(elem, ['slide', 'case', 'filename',
-                                                  'magnification', 'read_mode'],
-                                          [slide, case, filename,
-                                           magnification, 'tiled']),
-                  num_parallel_calls=tf.data.experimental.AUTOTUNE)
-
-  #add chunk parameters
-  read = read.map(lambda elem:
-                  _add_fields(elem, ['level', 'factor'],
-                              [level, 1.0]),
-                  num_parallel_calls=tf.data.experimental.AUTOTUNE)
-
-  #**** error if mismatch between tile size and read chunk size ****
-
-  #generate list of tile coordinates (local frame, upper-left corner)
-  read = read.map(lambda elem:
-                  _add_tile_coords_fields(elem, tile, overlap),
-                  num_parallel_calls=tf.data.experimental.AUTOTUNE)
-
-  #apply this function to the read chunk dataset
-  read = read.map(_read_chunk, num_parallel_calls=tf.data.experimental.AUTOTUNE)
-
-  #expand dimensions to match number of tiles
-  read = read.map(lambda element:
-                  _expand_tensors(element, ['slide', 'filename', 'case',
-                                            'magnification', 'cx', 'cy',
-                                            'cw', 'ch', 'level', 'factor',
-                                            'ow', 'oh',
-                                            'read_mode'], 'tx'),
-                  num_parallel_calls=tf.data.experimental.AUTOTUNE)
-
-  #flatten dataset to make each element one tile
-  tiled = read.flat_map(lambda element:
-                        tf.data.Dataset.from_tensor_slices(element))
-
-  #split tile, metadata into tuple
-  tiled = tiled.map(lambda element: (element.pop('tiles'), element))
-
-  return tiled
-
 def strategyExample():
   #find available GPUs
   devices=[gpu.name.replace('/physical_device:', '/').lower() for gpu in tf.config.experimental.list_physical_devices('GPU')]
@@ -338,27 +46,67 @@ def strategyExample():
 
 def readExample():
   tic = time.time()
-  #using numpy_function allows mapping of keras functions to dataset elements
 
   devices, strategy, model = strategyExample()
 
-  #set slide and read parameters
-  filename='TCGA-BH-A0BZ-01Z-00-DX1.45EB3E93-A871-49C6-9EAE-90D98AE01913.svs'
-  slide='TCGA-BH-A0BZ-01Z-00-DX1.45EB3E93-A871-49C6-9EAE-90D98AE01913'
-  case='TCGA-BH-A0BZ'
-  magnification=20.0
-  tile=(tf.constant(256, dtype=tf.int32),
-        tf.constant(256, dtype=tf.int32))
-  chunkFactor=(tf.constant(8, dtype=tf.int32),
-               tf.constant(8, dtype=tf.int32))
-  overlap=(tf.constant(0, dtype=tf.int32),
-           tf.constant(0, dtype=tf.int32))
+  # Each key=value pair in the dictionary should have a value that is
+  # a list of the same length.  Taken together, the Nth entry from
+  # each list comprise a dictionary that is the Nth element in the
+  # dataset.
+  header = {
+    'slide': ['TCGA-BH-A0BZ-01Z-00-DX1.45EB3E93-A871-49C6-9EAE-90D98AE01913'],
+    'case': ['TCGA-BH-A0BZ'],
+    'filename': ['TCGA-BH-A0BZ-01Z-00-DX1.45EB3E93-A871-49C6-9EAE-90D98AE01913.svs'],
+    'magnification': [20.0],
+    'read_mode': ['tiled'],
+  }
+  tiles = tf.data.Dataset.from_tensor_slices(header)
+
+  # For the desired magnification, find the best level stored in the
+  # image file, and its associated factor, width, and height.
+  tiles = tiles.map(tf_ComputeReadParameters)
+
+  # We are going to use a regularly spaced tiling for each of our
+  # dataset elements.  To begin, set the desired tile width, height,
+  # width overlap, and height overlap for each element, and indicate
+  # whether we want tiles even if they are fractional (aka of
+  # truncated size) due to partially falling off the edge of the
+  # image.  (These fractional tiles can be problematic because
+  # tensorflow likes its shapes to be uniform.)
+  tileWidth = tf.constant(256, dtype=tf.int32)
+  tileHeight = tileWidth
+  overlapWidth = tf.constant(0, dtype=tf.int32)
+  overlapHeight = overlapWidth
+  # (chunkWidthFactor, chunkHeightFactor) indicates how many
+  # (overlapping) tiles are read at a time.
+  chunkWidthFactor = tf.constant(8, dtype=tf.int32)
+  chunkHeightFactor = chunkWidthFactor
+  fractional = tf.constant(False, dtype=tf.bool)
+  newFields = {'tw': tileWidth, 'th': tileHeight,
+               'ow': overlapWidth, 'oh': overlapHeight,
+               'cwf': chunkWidthFactor, 'chf': chunkHeightFactor,
+               'fractional': fractional}
+  tiles = tiles.map(lambda elem: {**elem, **newFields})
+
+  # Split each element (e.g. each slide) into a batch of multiple
+  # rows, one per chunk to be read.  Note that the width `cw` or
+  # height `ch` of a row (chunk) may decreased from the requested
+  # value if a chunk is near the edge of an image.  Note that it is
+  # important to call `.unbatch()` when it is desired that the chunks
+  # be not batched by slide.
+  tiles = tiles.map(tf_ComputeChunkPositions).unbatch()
+
+  # Read and split the chunks into the tile size we want.  Note that
+  # it is important to call `.unbatch()` when it is desired that the
+  # tiles be not batched by chunk.
+  tiles = tiles.map(tf_ReadAndSplitChunk).prefetch(1).unbatch()
+
+  # Change the element to be of the form `(tile, metadataDictionary)`
+  # rather than `alldataDictionary`.
+  tiles = tiles.map(lambda elem: (elem.pop('tile'), elem))
+
   AUTOTUNE = tf.data.experimental.AUTOTUNE
   batch_size = 128*len(devices)
-
-  #generate tiles dataset
-  tiles = tiled(filename, slide, case, magnification,
-                tile, overlap, chunkFactor, mask=None)
 
   #batch tiles
   batched = tiles.batch(batch_size)
@@ -432,3 +180,132 @@ def outputExample(features, metadata):
   print('Writing h5 data: %f seconds' % (time.time() - tic))
 
   #write superpixel boundaries to disk
+
+
+def py_ComputeReadParameters(filenameIn, magnificationIn, toleranceIn):
+  filename = filenameIn.numpy()
+  magnification = magnificationIn.numpy()
+  tolerance = toleranceIn.numpy()
+
+  #read whole-slide image file and create openslide object
+  os_obj = os.OpenSlide(filename)
+
+  #measure objective of level 0
+  objective = np.float32(os_obj.properties[os.PROPERTY_NAME_OBJECTIVE_POWER])
+
+  #calculate magnifications of levels
+  estimated = np.array(objective / os_obj.level_downsamples)
+
+  #calculate difference with magnification levels
+  delta = magnification - estimated
+
+  #match to existing levels
+  if np.min(np.abs(np.divide(delta, magnification))) < tolerance: #match
+    level = np.squeeze(np.argmin(np.abs(delta)))
+    factor = 1.0
+  elif np.any(delta < 0):
+    value = np.max(delta[delta < 0])
+    level = np.squeeze(np.argwhere(delta == value)[0])
+    factor = magnification / estimated[level]
+  else: #desired magnification above base level - throw error
+    raise ValueError('Cannot interpolate above scan magnification.')
+
+  #get slide width, height at desired magnification
+  width, height = os_obj.level_dimensions[level]
+
+  return level, factor, width, height
+
+
+def tf_ComputeReadParameters(elem, tolerance = tf.constant(0.02, dtype=tf.float32)):
+  level, factor, width, height = tf.py_function(
+    func=py_ComputeReadParameters,
+    inp=[elem['filename'], elem['magnification'], tolerance],
+    Tout=(tf.int32, tf.float32, tf.int32, tf.int32))
+  return {**elem, 'level': level, 'factor': factor, 'width': width, 'height': height }
+
+
+def tf_ComputeChunkPositions(elem):
+  zero = tf.constant(0, dtype=tf.int32)
+  one = tf.constant(1, dtype=tf.int32)
+  chunkWidth = elem['cwf'] * (elem['tw'] - elem['ow']) + elem['ow']
+  chunkHeight = elem['chf'] * (elem['th'] - elem['oh']) + elem['oh']
+
+  ## The left side of a tile cannot be as large as left_bound.  Also,
+  ## the left side of a chunk cannot be as large as left_bound because
+  ## chunks contain a whole number of tiles.
+  left_bound = tf.maximum(zero,
+                          elem['width'] - elem['ow'] if elem['fractional'] else elem['width'] - elem['tw'] + one)
+  chunkLeft = tf.range(zero, left_bound, chunkWidth - elem['ow'])
+  chunkRight = tf.clip_by_value(chunkLeft + chunkWidth, zero, elem['width'])
+
+  top_bound = tf.maximum(zero,
+                         elem['height'] - elem['oh'] if elem['fractional'] else elem['height'] - elem['th'] + one)
+  chunkTop = tf.range(zero, top_bound, chunkHeight - elem['oh'])
+  chunkBottom = tf.clip_by_value(chunkTop + chunkHeight, zero, elem['height'])
+
+  x = tf.tile(chunkLeft, tf.stack([tf.size(chunkTop)]))
+  w = tf.tile(chunkRight-chunkLeft, tf.stack([tf.size(chunkTop)]))
+  y = tf.repeat(chunkTop, tf.size(chunkLeft))
+  h = tf.repeat(chunkBottom-chunkTop, tf.size(chunkLeft))
+  len = tf.size(x)
+
+  response = {}
+  for key in elem.keys():
+    response[key] = tf.repeat(elem[key], len)
+  return {**response, 'cx': x, 'cy': y, 'cw': w, 'ch': h}
+
+
+def py_ReadChunk(filename, level, x, y, w, h):
+  #open slide
+  os_obj = os.OpenSlide(filename.numpy())
+
+  #read chunk and convert to tensor
+  chunk = os_obj.read_region((x.numpy(), y.numpy()),
+                             level.numpy(),
+                             (w.numpy(), h.numpy()))
+
+  return tf.convert_to_tensor(np.array(chunk)[...,:3], dtype=tf.uint8)
+
+
+def tf_ReadAndSplitChunk(elem):
+  zero = tf.constant(0, dtype=tf.int32)
+  one = tf.constant(1, dtype=tf.int32)
+  left_bound = tf.maximum(zero,
+                          elem['cw'] - elem['ow'] if elem['fractional'] else elem['cw'] - elem['tw'] + one)
+  tileLeft = tf.range(zero, left_bound, elem['tw'] - elem['ow'])
+  tileRight = tf.clip_by_value(tileLeft + elem['tw'], zero, elem['cw'])
+
+  top_bound = tf.maximum(zero,
+                         elem['ch'] - elem['oh'] if elem['fractional'] else elem['ch'] - elem['th'] + one)
+  tileTop = tf.range(zero, top_bound, elem['th'] - elem['oh'])
+  tileBottom = tf.clip_by_value(tileTop + elem['th'], zero, elem['ch'])
+
+  x = tf.tile(tileLeft, tf.stack([tf.size(tileTop)]))
+  w = tf.tile(tileRight-tileLeft, tf.stack([tf.size(tileTop)]))
+  y = tf.repeat(tileTop, tf.size(tileLeft))
+  h = tf.repeat(tileBottom-tileTop, tf.size(tileLeft))
+  len = tf.size(x)
+
+  chunk = tf.py_function(
+            func=py_ReadChunk,
+            inp=[elem['filename'], elem['level'], elem['cx'], elem['cy'], elem['cw'], elem['ch']],
+            Tout=tf.uint8)
+
+  tiles = tf.TensorArray(dtype=tf.uint8, size=len)
+  condition = lambda i, _: tf.less(i, len)
+  body = lambda i, tiles: (
+    i+1, tiles.write(
+      i, tf.image.crop_to_bounding_box(chunk,
+                                       tf.gather(y, i),
+                                       tf.gather(x, i),
+                                       tf.gather(h, i),
+                                       tf.gather(w, i))))
+  _, tiles = tf.while_loop(condition, body, [0, tiles])
+  tiles = tiles.stack()
+  del chunk
+
+  response = {}
+  for key in elem.keys():
+    response[key] = tf.repeat(elem[key], len)
+
+  return {**response, 'tx': elem['cx']+x, 'ty': elem['cy']+y, 'tw': w, 'th': h, 'tile': tiles}


### PR DESCRIPTION
This constructs the input dataset using tensorflow graph constructs.  In theory, this allows tensorflow to optimize the order of the steps so as to maximize performance.  However, it is about 4 times slower than the implementation that it replaces.  I am putting it here for soliciting feedback, and in case it proves useful in the future to have this documented.  

**See comments below as to why this is now a pull request that can be merged.**