### PR TITLE
ENH: Add superpixel jupyter notebook

### DIFF
--- a/superpixel.ipynb
+++ b/superpixel.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "id": "SqF9JwMGE4On"
+   },
+   "source": [
+    "!python -m pip install -U pip\n",
+    "!python -m pip install -U setuptools\n",
+    "!python -m pip install -U wheel\n",
+    "!python -m pip install histomicstk --pre --find-links  https://girder.github.io/large_image_wheels\n",
+    "!python -m pip install SimpleITK\n",
+    "!python -m pip install fast_slic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 409
+    },
+    "id": "7Yt9ELdxEje2",
+    "outputId": "a5b91a6f-e767-4595-8786-845bd2423228"
+   },
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import histomicstk as htk\n",
+    "\n",
+    "from histomicstk.segmentation.label import trace_object_boundaries\n",
+    "from histomicstk.utils import merge_colinear\n",
+    "\n",
+    "from skimage.data import astronaut\n",
+    "from skimage.measure import regionprops_table\n",
+    "from skimage.segmentation import slic\n",
+    "from skimage.segmentation import mark_boundaries\n",
+    "from skimage.util import img_as_float\n",
+    "\n",
+    "import SimpleITK as sitk\n",
+    "\n",
+    "from fast_slic import Slic\n",
+    "\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 409
+    },
+    "id": "7Yt9ELdxEje2",
+    "outputId": "a5b91a6f-e767-4595-8786-845bd2423228"
+   },
+   "outputs": [],
+   "source": [
+    "#trace and simplify superpixel boundaries\n",
+    "def plotit(countFigure, img, label):\n",
+    "  start = time.time()\n",
+    "  Y, X = trace_object_boundaries(label, conn=4, trace_all=True,\n",
+    "                                   simplify_colinear_spurs=True,\n",
+    "                                   eps_colinear_area=0.01)\n",
+    "  X, Y = zip(*[merge_colinear(x,y) for x,y in zip(X,Y)])\n",
+    "  print('Tracing time elapsed: {}'.format(time.time()-start))\n",
+    "\n",
+    "\n",
+    "  #offset by tile boundaries\n",
+    "\n",
+    "  #get superpixel centroids\n",
+    "  centroids = regionprops_table(label, properties=['centroid'])\n",
+    "  cY = centroids['centroid-0']\n",
+    "  cX = centroids['centroid-1']\n",
+    "  \n",
+    "  fig, ax = plt.subplots(num=countFigure)\n",
+    "  ax.imshow(img)\n",
+    "  fig.gca().set_axis_off()\n",
+    "  fig.tight_layout()\n",
+    "  ax.scatter(cX, cY)\n",
+    "  for x,y in zip(X, Y):\n",
+    "    ax.plot(x, y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 409
+    },
+    "id": "7Yt9ELdxEje2",
+    "outputId": "a5b91a6f-e767-4595-8786-845bd2423228"
+   },
+   "outputs": [],
+   "source": [
+    "img = img_as_float(astronaut()[::2, ::2])\n",
+    "img = np.tile(img, (8,8,1))\n",
+    "\n",
+    "#skimage\n",
+    "start = time.time()\n",
+    "label1 = slic(img, n_segments=int(img.shape[0]*img.shape[1]/4096.0), compactness=1, sigma=1, start_label=1)\n",
+    "print('skimage SLIC time elapsed: %s ' % format(time.time()-start))\n",
+    "\n",
+    "#Simple ITK\n",
+    "start = time.time()\n",
+    "imgITK = sitk.GetImageFromArray(img, isVector=True)\n",
+    "labelITK = sitk.SLIC(imgITK, spatialProximityWeight=1.0, superGridSize=(64,64))\n",
+    "label2 = sitk.GetArrayFromImage(labelITK)\n",
+    "print('SITK SLIC time elapsed: %s ' % format(time.time()-start))\n",
+    "\n",
+    "#fast_slic: algorithm is suspect\n",
+    "start = time.time()\n",
+    "slic = Slic(num_components=int(img.shape[0]*img.shape[1]/(64.0*64.0)), compactness=1)\n",
+    "imgFastSLIC = img.astype(np.uint8)\n",
+    "label3 = slic.iterate(imgFastSLIC)\n",
+    "print('fast_slic time elapsed: %s ' % format(time.time()-start))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "countFigure = 0\n",
+    "fig, ax = plt.subplots(num=countFigure)\n",
+    "countFigure = countFigure + 1\n",
+    "ax.imshow(img)\n",
+    "\n",
+    "plotit(countFigure, img, label1)\n",
+    "countFigure = countFigure + 1\n",
+    "plotit(countFigure, img, label2)\n",
+    "countFigure = countFigure + 1\n",
+    "plotit(countFigure, img, label3)\n",
+    "countFigure = countFigure + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "superpixel.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "superpixel",
+   "language": "python",
+   "name": "superpixel"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This is adapted from a version by @cooperlab.

This code compares three implementations of the SLIC algorithm for computing superpixels from an image.  The `skimage` and `Simple ITK` versions produce reasonable results; the `fast_slic` version is not producing reasonable results.  By default, this code is running on an 8 × 8 tiling of an image of an astronaut.  Set it to 1 × 2 or 2 × 2 to see more detail.

The runtime for `skimage` is 3.7 seconds, for `Simple ITK` is 0.46 seconds, and for `fast_slic` is 0.10 seconds.  Because the output of the last is suspicious, these timings support the use of `Simple ITK`, though further investigation to the quality of the superpixel construction is warranted.