### PR TITLE
ENH: TensorFlow graph handles tile-selection mask

### DIFF
--- a/Zarr Size Comparison.ipynb
+++ b/Zarr Size Comparison.ipynb
@@ -34,7 +34,7 @@
     "from numcodecs import Blosc\n",
     "from napari_lazy_openslide.lazy_openslide import OpenSlideStore\n",
     "from matplotlib import pyplot as plt\n",
-    "from tensorflow_reader import kwjpeg, jpeg2k, zarr_codec\n",
+    "from tensorflow_reader import kwjpeg, jpeg2k\n",
     "from zarr_jpeg import jpeg\n",
     "%matplotlib inline\n",
     "print(blosc.list_compressors())"

--- a/wsi_reader.ipynb
+++ b/wsi_reader.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "from datetime import datetime\n",
     "from packaging import version\n",
-    "from zarr_jpeg import jpeg\n",
+    "import itk\n",
     "import os\n",
     "import tensorflow as tf\n",
     "import tensorflow_reader as tfr\n",
@@ -95,14 +95,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:tensorflow:Using MirroredStrategy with devices ('/job:localhost/replica:0/task:0/device:GPU:0', '/job:localhost/replica:0/task:0/device:GPU:1', '/job:localhost/replica:0/task:0/device:GPU:2', '/job:localhost/replica:0/task:0/device:GPU:3', '/job:localhost/replica:0/task:0/device:GPU:4', '/job:localhost/replica:0/task:0/device:GPU:5', '/job:localhost/replica:0/task:0/device:GPU:6')\n",
-      "strategyExample: 7.718057 seconds\n",
-      "['/gpu:0', '/gpu:1', '/gpu:2', '/gpu:3', '/gpu:4', '/gpu:5', '/gpu:6']\n"
+      "INFO:tensorflow:Using MirroredStrategy with devices ('/job:localhost/replica:0/task:0/device:GPU:0', '/job:localhost/replica:0/task:0/device:GPU:1', '/job:localhost/replica:0/task:0/device:GPU:2', '/job:localhost/replica:0/task:0/device:GPU:3', '/job:localhost/replica:0/task:0/device:GPU:4', '/job:localhost/replica:0/task:0/device:GPU:5', '/job:localhost/replica:0/task:0/device:GPU:6', '/job:localhost/replica:0/task:0/device:GPU:7')\n",
+      "strategy_example: 8.451401 seconds\n",
+      "['/gpu:0', '/gpu:1', '/gpu:2', '/gpu:3', '/gpu:4', '/gpu:5', '/gpu:6', '/gpu:7']\n"
      ]
     }
    ],
    "source": [
-    "devices, strategy, model = tfr.strategyExample()\n",
+    "devices, strategy, model = tfr.strategy_example()\n",
     "print(devices)"
    ]
   },
@@ -124,13 +124,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "readExample: 1.363249 seconds\n"
+      "Image source = ['TCGA-BH-A0BZ-01Z-00-DX1.45EB3E93-A871-49C6-9EAE-90D98AE01913.svs']\n",
+      "all_masks = ['TCGA-BH-A0BZ-01Z-00-DX1.45EB3E93-A871-49C6-9EAE-90D98AE01913-mask.png']\n",
+      "read_example: 2.313699 seconds\n"
      ]
     }
    ],
    "source": [
     "with strategy.scope():\n",
-    "    batched_dist = tfr.readExample(devices, strategy)"
+    "    batched_dist = tfr.read_example(devices, strategy)"
    ]
   },
   {
@@ -142,13 +144,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "predictExample: 72.716125 seconds\n"
+      "level = 0, factor = 0.5, width = 112334, height = 85047\n",
+      "width_scale = 1.0\n",
+      "height_scale = 1.0\n",
+      "padded_resampled_numpy.shape = (336, 440, 1)\n",
+      "predict_example: 80.992825 seconds\n"
      ]
     }
    ],
    "source": [
     "with strategy.scope():\n",
-    "    features, metadata = tfr.predictExample(model, batched_dist, strategy)"
+    "    features, metadata = tfr.predict_example(model, batched_dist, strategy)"
    ]
   },
   {
@@ -160,13 +166,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "outputExample: 15.125955 seconds\n"
+      "output_example: 7.617830 seconds\n"
      ]
     }
    ],
    "source": [
     "with strategy.scope():\n",
-    "    tfr.outputExample(features, metadata)"
+    "    tfr.output_example(features, metadata)"
    ]
   },
   {
@@ -178,7 +184,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total running time: 96.990725 seconds for 7 devices\n"
+      "Total running time: 99.431946 seconds for 8 devices\n"
      ]
     }
    ],


### PR DESCRIPTION
A mask file can be supplied to determine which tiles from a whole slide image should be retained for learning or inference.  This mask is first [resampled](https://itk.org/ITKExamples/src/Filtering/ImageGrid/ResampleAnImage/Documentation.html) if necessary so that it has exactly one pixel for each and every tile that could be selected for subsequent processing.  A non-zero value for a pixel indicates that the corresponding tile should be kept.

Also,
    ENH: Stop using zarr-jpeg package, which is problematic in our context
    STYLE: Use snake_case for Python function and variable names
