### PR TITLE
ENH: Implement mask resampling via tensorflow

### DIFF
--- a/wsi_reader.ipynb
+++ b/wsi_reader.ipynb
@@ -96,7 +96,7 @@
      "output_type": "stream",
      "text": [
       "INFO:tensorflow:Using MirroredStrategy with devices ('/job:localhost/replica:0/task:0/device:GPU:0', '/job:localhost/replica:0/task:0/device:GPU:1', '/job:localhost/replica:0/task:0/device:GPU:2', '/job:localhost/replica:0/task:0/device:GPU:3', '/job:localhost/replica:0/task:0/device:GPU:4', '/job:localhost/replica:0/task:0/device:GPU:5', '/job:localhost/replica:0/task:0/device:GPU:6', '/job:localhost/replica:0/task:0/device:GPU:7')\n",
-      "strategy_example: 8.451401 seconds\n",
+      "strategy_example: 8.670114 seconds\n",
       "['/gpu:0', '/gpu:1', '/gpu:2', '/gpu:3', '/gpu:4', '/gpu:5', '/gpu:6', '/gpu:7']\n"
      ]
     }
@@ -126,7 +126,7 @@
      "text": [
       "Image source = ['TCGA-BH-A0BZ-01Z-00-DX1.45EB3E93-A871-49C6-9EAE-90D98AE01913.svs']\n",
       "all_masks = ['TCGA-BH-A0BZ-01Z-00-DX1.45EB3E93-A871-49C6-9EAE-90D98AE01913-mask.png']\n",
-      "read_example: 2.313699 seconds\n"
+      "read_example: 2.374598 seconds\n"
      ]
     }
    ],
@@ -145,10 +145,7 @@
      "output_type": "stream",
      "text": [
       "level = 0, factor = 0.5, width = 112334, height = 85047\n",
-      "width_scale = 1.0\n",
-      "height_scale = 1.0\n",
-      "padded_resampled_numpy.shape = (336, 440, 1)\n",
-      "predict_example: 80.992825 seconds\n"
+      "predict_example: 82.014220 seconds\n"
      ]
     }
    ],
@@ -166,7 +163,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "output_example: 7.617830 seconds\n"
+      "output_example: 7.581701 seconds\n"
      ]
     }
    ],
@@ -184,7 +181,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total running time: 99.431946 seconds for 8 devices\n"
+      "Total running time: 100.713276 seconds for 8 devices\n"
      ]
     }
    ],


### PR DESCRIPTION
Patch to do mask resampling (from supplied size (in pixels) to one pixel per tile) via tensorflow rather than via ITK.