### PR TITLE
ENH: New architecture: supply callable classes to tf.dataset.map()

### DIFF
--- a/wsi_reader.ipynb
+++ b/wsi_reader.ipynb
@@ -95,9 +95,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:tensorflow:Using MirroredStrategy with devices ('/job:localhost/replica:0/task:0/device:GPU:0', '/job:localhost/replica:0/task:0/device:GPU:1', '/job:localhost/replica:0/task:0/device:GPU:2', '/job:localhost/replica:0/task:0/device:GPU:3', '/job:localhost/replica:0/task:0/device:GPU:4', '/job:localhost/replica:0/task:0/device:GPU:5', '/job:localhost/replica:0/task:0/device:GPU:6', '/job:localhost/replica:0/task:0/device:GPU:7')\n",
-      "strategy_example: 8.670114 seconds\n",
-      "['/gpu:0', '/gpu:1', '/gpu:2', '/gpu:3', '/gpu:4', '/gpu:5', '/gpu:6', '/gpu:7']\n"
+      "INFO:tensorflow:Using MirroredStrategy with devices ('/job:localhost/replica:0/task:0/device:GPU:0', '/job:localhost/replica:0/task:0/device:GPU:1', '/job:localhost/replica:0/task:0/device:GPU:2', '/job:localhost/replica:0/task:0/device:GPU:3')\n",
+      "strategy_example: 6.991709 seconds\n",
+      "['/gpu:0', '/gpu:1', '/gpu:2', '/gpu:3']\n"
      ]
     }
    ],
@@ -126,7 +126,7 @@
      "text": [
       "Image source = ['TCGA-BH-A0BZ-01Z-00-DX1.45EB3E93-A871-49C6-9EAE-90D98AE01913.svs']\n",
       "all_masks = ['TCGA-BH-A0BZ-01Z-00-DX1.45EB3E93-A871-49C6-9EAE-90D98AE01913-mask.png']\n",
-      "read_example: 2.374598 seconds\n"
+      "read_example: 3.288696 seconds\n"
      ]
     }
    ],
@@ -145,7 +145,7 @@
      "output_type": "stream",
      "text": [
       "level = 0, factor = 0.5, width = 112334, height = 85047\n",
-      "predict_example: 82.014220 seconds\n"
+      "predict_example: 89.820471 seconds\n"
      ]
     }
    ],
@@ -163,7 +163,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "output_example: 7.581701 seconds\n"
+      "output_example: 5.212903 seconds\n"
      ]
     }
    ],
@@ -181,7 +181,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total running time: 100.713276 seconds for 8 devices\n"
+      "Total running time: 105.375309 seconds for 4 devices\n"
      ]
     }
    ],


### PR DESCRIPTION
Instead of supplying lambda expressions or other functions as the first parameter to `tensorflow.dataset.map()` calls, we now supply callable classes.  For each callable class, this makes initialization code be encapsulated in the `__init__` method and the actual dataset manipulation be encapsulated in the `__call__` method.  Subroutines of these methods are encapsulated as private methods of the callable classes.

The steps of a function implementing a pipeline are now much simpler and more compact.  They require two basic operations, construction of the callable class and supplying the callable class to the `tensorflow.dataset.map()` function.  An entire pipeline might now fit on a single page because the parts that should be internal to any given pipeline step now are internal.