### PR TITLE
BUG: Make tensorflow graph know enough about mask parameters

### DIFF
--- a/histomics_stream/__init__.py
+++ b/histomics_stream/__init__.py
@@ -65,9 +65,7 @@ def strategy_example():
     # generate network model
     with strategy.scope():
         model = tf.keras.applications.VGG16(include_top=True, weights="imagenet")
-        model = tf.keras.Model(
-            inputs=model.input, outputs=model.get_layer("fc1").output
-        )
+        model = tf.keras.Model(inputs=model.input, outputs=model.get_layer("fc1").output)
 
     print("strategy_example: %f seconds" % (time.time() - tic))
     return devices, strategy, model
@@ -2311,9 +2309,7 @@ def read_example(devices, strategy):
     # all_wsi_images = ["RGBA/zstd_compressor1024.zarr"]
     # all_wsi_images = ["RGBA/zstd_compressor2048.zarr"]
 
-    all_wsi_images = [
-        "TCGA-BH-A0BZ-01Z-00-DX1.45EB3E93-A871-49C6-9EAE-90D98AE01913.svs"
-    ]
+    all_wsi_images = ["TCGA-BH-A0BZ-01Z-00-DX1.45EB3E93-A871-49C6-9EAE-90D98AE01913.svs"]
     # all_wsi_images = ["default1024.zarr"]
     # all_wsi_images = ["default2048.zarr"]
     # all_wsi_images = ["default256.zarr"]
@@ -2335,9 +2331,7 @@ def read_example(devices, strategy):
     # build the mask name from the WSI file name, by inserting "-mask" and changing the file type to
     # "png", but generally any file name and any file type that we can read as an image will do.
 
-    all_masks = [
-        re.sub(r"^(.*)\.([^\.]*)$", r"\1-mask.png", wsi) for wsi in all_wsi_images
-    ]
+    all_masks = [re.sub(r"^(.*)\.([^\.]*)$", r"\1-mask.png", wsi) for wsi in all_wsi_images]
     print(f"all_masks = {all_masks}")
 
     header = dict(
@@ -2475,9 +2469,7 @@ def output_example(features, metadata):
             dtype=h5py.string_dtype(encoding="ascii"),
         )
         handle.create_dataset("features", data=features.numpy(), dtype="float")
-        handle.create_dataset(
-            "slideIdx", data=np.zeros(metadata["slide"].shape), dtype="int"
-        )
+        handle.create_dataset("slideIdx", data=np.zeros(metadata["slide"].shape), dtype="int")
         handle.create_dataset("x_centroid", data=metadata["tx"].numpy(), dtype="float")
         handle.create_dataset("y_centroid", data=metadata["ty"].numpy(), dtype="float")
         handle.create_dataset("dataIdx", data=np.zeros(1), dtype="int")
@@ -2564,9 +2556,7 @@ def _convert_openslide_to_chunks(
     for left, right in zip(chunk_left, chunk_right):
         for top, bottom in zip(chunk_top, chunk_bottom):
             # Read in chunk
-            chunk = np.array(
-                os_obj.read_region((left, top), level, (right - left, bottom - top))
-            )
+            chunk = np.array(os_obj.read_region((left, top), level, (right - left, bottom - top)))
             assert len(chunk.shape) == 3
             assert 3 <= chunk.shape[2] <= 4
             # Make sure that we have RGB rather than RGBA

--- a/histomics_stream/ds/init.py
+++ b/histomics_stream/ds/init.py
@@ -34,7 +34,8 @@ class Header:
     mask_filenames : str
         A list of masks for the slides.  Each slide's mask will be used to select which tiles of the
         slide to process.  If the mask does not have one pixel per tile then it will be upsampled or
-        downsampled as necessary.
+        downsampled as necessary.  An empty string indicates that no mask file is being supplied and
+        that all tiles should be retained.
 
     Notes
     -----
@@ -42,9 +43,7 @@ class Header:
 
     """
 
-    def __init__(
-        self, slides, filenames, cases, magnifications, read_modes, mask_filenames
-    ):
+    def __init__(self, slides, filenames, cases, magnifications, read_modes, mask_filenames):
         self.dictionary = {
             "slide": slides,
             "filename": filenames,


### PR DESCRIPTION
This fixes a bug where histomics_stream could not handle a mask for selecting tiles from a whole-slide image.  The problem was that the graph construction by tensorflow could not figure out tensor shapes because it was not clear to tensorflow that the shape was deterministic despite the presence of some `if` statements.  